### PR TITLE
feat: improve plan type selection and prompts

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -51,17 +51,17 @@
         .nav-link { padding: 0.5rem 1rem; border-radius: 0.375rem; transition: background-color 0.2s, color 0.2s; }
         .nav-link.active { background-color: #7A9D54; color: white; }
         .nav-link:not(.active):hover { background-color: #f3f4f6; }
-        .school-level-btn {
+        .school-level-btn, .plan-type-btn {
             transition: all 0.2s;
             border: 2px solid transparent;
         }
-        .school-level-btn.active {
+        .school-level-btn.active, .plan-type-btn.active {
             background-color: #84cc16; /* lime-500 */
             color: white;
             border-color: #65a30d; /* lime-600 */
             font-weight: 600;
         }
-        .school-level-btn:not(.active) {
+        .school-level-btn:not(.active), .plan-type-btn:not(.active) {
             background-color: #f1f5f9; /* slate-100 */
             color: #475569; /* slate-600 */
         }
@@ -159,12 +159,9 @@
                                     </div>
                                 </div>
                                 <div>
-                                    <label for="plan-type" class="block text-sm font-medium text-gray-700">계획서 주제</label>
-                                    <select id="plan-type" class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-green-500 sm:text-sm"></select>
-                                    <button type="button" id="custom-topic-btn" class="mt-2 text-sm text-blue-600 hover:underline">직접 입력</button>
-                                    <div id="custom-plan-type-wrapper" class="hidden mt-2">
-                                        <input type="text" id="custom-plan-type" placeholder="계획서 주제를 직접 입력하세요" class="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-green-500 sm:text-sm">
-                                    </div>
+                                    <label class="block text-sm font-medium text-gray-700 mb-2">계획서 주제</label>
+                                    <div id="plan-type-buttons" class="grid grid-cols-2 gap-2"></div>
+                                    <input type="text" id="custom-plan-type" placeholder="계획서 주제를 직접 입력하세요" class="block w-full mt-2 px-3 py-2 border border-gray-300 rounded-md shadow-sm placeholder-gray-400 focus:outline-none focus:ring-green-500 sm:text-sm">
                                 </div>
                                 
                                 <div>
@@ -476,9 +473,7 @@
         const toast = document.getElementById('toast');
         const outputPanel = document.getElementById('output-panel');
         const schoolLevelButtons = document.getElementById('school-level-buttons');
-        const planTypeSelect = document.getElementById('plan-type');
-        const customTopicBtn = document.getElementById('custom-topic-btn');
-        const customPlanTypeWrapper = document.getElementById('custom-plan-type-wrapper');
+        const planTypeButtons = document.getElementById('plan-type-buttons');
         const customPlanTypeInput = document.getElementById('custom-plan-type');
         const keywordsContainer = document.getElementById('keywords-container');
         const addKeywordBtn = document.getElementById('add-keyword-btn');
@@ -1290,7 +1285,7 @@
                 return;
             }
 
-            const standardTypes = ['학교폭력 예방 교육 계획', '진로 체험 활동 계획', '디지털 리터러시 교육 계획', '기초학력 향상 지원 계획', '다문화 교육 활동 계획', '초등학교 교육과정 운영계획'];
+            const standardTypes = ['학교폭력 예방 교육 계획', '진로 체험 활동 계획', '디지털 리터러시 교육 계획', '기초학력 향상 지원 계획', '다문화 교육 활동 계획', '교육과정 운영계획'];
             const stats = { '기타': 0 };
             standardTypes.forEach(t => stats[t] = 0);
 
@@ -1592,8 +1587,10 @@
         // --- GENERATOR LOGIC ---
         
         const populateSelects = () => {
-            const planTypes = ['초등학교 교육과정 운영계획', '학교폭력 예방 교육 계획', '진로 체험 활동 계획', '디지털 리터러시 교육 계획', '기초학력 향상 지원 계획', '다문화 교육 활동 계획'];
-            planTypeSelect.innerHTML = planTypes.map(type => `<option value="${type}">${type}</option>`).join('');
+            const planTypes = ['교육과정 운영계획', '학교폭력 예방 교육 계획', '진로 체험 활동 계획', '디지털 리터러시 교육 계획', '기초학력 향상 지원 계획', '다문화 교육 활동 계획'];
+            planTypeButtons.innerHTML = planTypes.map(type => `<button type="button" data-value="${type}" class="plan-type-btn py-2 px-3 rounded-md text-sm">${type}</button>`).join('');
+            const firstBtn = planTypeButtons.querySelector('button');
+            if (firstBtn) firstBtn.classList.add('active');
         };
 
         schoolLevelButtons.addEventListener('click', (e) => {
@@ -1603,11 +1600,13 @@
             }
         });
 
-        customTopicBtn.addEventListener('click', () => {
-            customPlanTypeWrapper.classList.toggle('hidden');
-            planTypeSelect.disabled = !customPlanTypeWrapper.classList.contains('hidden');
+        planTypeButtons.addEventListener('click', (e) => {
+            if (e.target.tagName === 'BUTTON') {
+                planTypeButtons.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
+                e.target.classList.add('active');
+            }
         });
-        
+
         addKeywordBtn.addEventListener('click', () => {
             const container = document.createElement('div');
             container.className = 'flex items-center gap-2';
@@ -1633,16 +1632,20 @@
             
             formError.classList.add('hidden');
 
-            let planType;
-            if (!customPlanTypeWrapper.classList.contains('hidden')) {
-                planType = customPlanTypeInput.value.trim();
-                if (!planType) {
-                    formError.textContent = '계획서 주제를 직접 입력해주세요.';
-                    formError.classList.remove('hidden');
-                    return;
-                }
+            const selectedPlanBtn = planTypeButtons.querySelector('.active');
+            const selectedPlanType = selectedPlanBtn ? selectedPlanBtn.dataset.value : '';
+            const customPlan = customPlanTypeInput.value.trim();
+            let planType = '';
+            if (selectedPlanType && customPlan) {
+                planType = `${selectedPlanType} ${customPlan}`;
+            } else if (selectedPlanType) {
+                planType = selectedPlanType;
+            } else if (customPlan) {
+                planType = customPlan;
             } else {
-                planType = planTypeSelect.value;
+                formError.textContent = '계획서 주제를 선택하거나 입력해주세요.';
+                formError.classList.remove('hidden');
+                return;
             }
             
             const schoolLevel = schoolLevelButtons.querySelector('.active').dataset.value;
@@ -1669,8 +1672,8 @@
 **섹션별 작성 조건:**
 1.  **목적**: 계획의 핵심 목표를 명확하고 간결하게箇条書き(bullet points) 형식으로 제시하세요.
 2.  **운영방침**: 계획을 실행하기 위한 기본 원칙과 방향을 箇条書き 형식으로 제시하세요.
-3.  **세부 운영 계획**: 이 섹션은 반드시 Markdown 테이블 형식으로 작성해야 합니다. 표에는 '구분', '추진 내용', '세부 추진 계획', '시기', '대상' 등의 구체적인 항목을 포함하여 상세하게 작성하세요.
-4.  **예산**: 이 섹션은 '항목', '산출 근거', '예산액(원)', '비고'를 포함한 Markdown 테이블 형식으로 작성해주세요. 실제적인 예산을 편성해야 합니다.
+3.  **세부 운영 계획**: 관련 내용을 간단한 문단으로 설명한 뒤, '구분', '추진 내용', '세부 추진 계획', '시기', '대상' 등의 항목을 포함한 Markdown 테이블을 추가하세요.
+4.  **예산**: 예산 편성 방향을 짧게 서술하고, 이어서 '항목', '산출 근거', '예산액(원)', '비고'를 포함한 Markdown 테이블을 제공하세요. 실제적인 예산을 편성해야 합니다.
 5.  **기대효과**: 계획 실행을 통해 예상되는 긍정적인 결과를 箇条書き 형식으로 구체적으로 서술하세요.
 - **핵심 키워드**: '${keywords.join(', ')}'를 계획서 전반에 자연스럽게 반영해주세요.
 - **중요**: 생성하는 모든 텍스트에서 마크다운 굵은 글씨(**)를 사용하지 마세요. 모든 내용은 일반 텍스트로만 작성해주세요.


### PR DESCRIPTION
## Summary
- change plan topic to button-based selection and allow extra text input
- rename 초등학교 교육과정 운영계획 to 교육과정 운영계획
- adjust generation prompts so 세부 운영 계획 and 예산 include text plus tables

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a810daf1a8832e809cc1635fd8976b