### PR TITLE
Refine plan input options layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -51,17 +51,17 @@
         .nav-link { padding: 0.5rem 1rem; border-radius: 0.375rem; transition: background-color 0.2s, color 0.2s; }
         .nav-link.active { background-color: #7A9D54; color: white; }
         .nav-link:not(.active):hover { background-color: #f3f4f6; }
-        .school-level-btn, .plan-type-btn, .outline-btn {
+        .school-level-btn, .plan-type-btn, .outline-btn, .category-btn {
             transition: all 0.2s;
             border: 2px solid transparent;
         }
-        .school-level-btn.active, .plan-type-btn.active, .outline-btn.active {
+        .school-level-btn.active, .plan-type-btn.active, .outline-btn.active, .category-btn.active {
             background-color: #84cc16; /* lime-500 */
             color: white;
             border-color: #65a30d; /* lime-600 */
             font-weight: 600;
         }
-        .school-level-btn:not(.active), .plan-type-btn:not(.active), .outline-btn:not(.active) {
+        .school-level-btn:not(.active), .plan-type-btn:not(.active), .outline-btn:not(.active), .category-btn:not(.active) {
             background-color: #f1f5f9; /* slate-100 */
             color: #475569; /* slate-600 */
         }
@@ -155,21 +155,22 @@
                                 </div>
                                 <div class="mt-4">
                                     <label class="block text-sm font-medium text-gray-700 mb-2">목차</label>
-                                    <div id="outline-buttons" class="grid grid-cols-2 gap-2">
-                                        <button type="button" data-value="기본 목차" class="outline-btn py-2 px-3 rounded-md text-sm active">기본 목차</button>
-                                        <button type="button" data-value="간단 목차A" class="outline-btn py-2 px-3 rounded-md text-sm">간단 목차A</button>
-                                        <button type="button" data-value="간단 목차B" class="outline-btn py-2 px-3 rounded-md text-sm">간단 목차B</button>
-                                        <button type="button" data-value="행정 목차" class="outline-btn py-2 px-3 rounded-md text-sm">행정 목차</button>
+                                    <div id="outline-buttons" class="flex flex-wrap gap-2">
+                                        <button type="button" data-value="기본 목차" class="outline-btn py-1 px-2 rounded text-xs active">기본 목차</button>
+                                        <button type="button" data-value="간단 목차A" class="outline-btn py-1 px-2 rounded text-xs">간단 목차A</button>
+                                        <button type="button" data-value="간단 목차B" class="outline-btn py-1 px-2 rounded text-xs">간단 목차B</button>
+                                        <button type="button" data-value="행정 목차" class="outline-btn py-1 px-2 rounded text-xs">행정 목차</button>
                                     </div>
                                 </div>
                                 <div class="mt-4">
                                     <label class="block text-sm font-medium text-gray-700 mb-2">분류</label>
-                                    <select id="plan-category" class="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-green-500 sm:text-sm">
-                                        <option value="정책 기획">정책 기획</option>
-                                        <option value="행사 기획">행사 기획</option>
-                                        <option value="장학 기획">장학 기획</option>
-                                        <option value="업무 보고">업무 보고</option>
-                                    </select>
+                                    <input type="hidden" id="plan-category" value="정책 기획">
+                                    <div id="category-buttons" class="flex flex-wrap gap-2">
+                                        <button type="button" data-value="정책 기획" class="category-btn py-1 px-2 rounded text-xs active">정책 기획</button>
+                                        <button type="button" data-value="행사 기획" class="category-btn py-1 px-2 rounded text-xs">행사 기획</button>
+                                        <button type="button" data-value="장학 기획" class="category-btn py-1 px-2 rounded text-xs">장학 기획</button>
+                                        <button type="button" data-value="업무 보고" class="category-btn py-1 px-2 rounded text-xs">업무 보고</button>
+                                    </div>
                                 </div>
                                 <div class="mt-4">
                                     <label class="block text-sm font-medium text-gray-700 mb-2">계획서 주제</label>
@@ -472,7 +473,8 @@
         const outputPanel = document.getElementById('output-panel');
         const schoolLevelButtons = document.getElementById('school-level-buttons');
         const outlineButtons = document.getElementById('outline-buttons');
-        const planCategorySelect = document.getElementById('plan-category');
+        const categoryButtons = document.getElementById('category-buttons');
+        const planCategoryInput = document.getElementById('plan-category');
         const customPlanTypeInput = document.getElementById('custom-plan-type');
         const keywordsContainer = document.getElementById('keywords-container');
         const addKeywordBtn = document.getElementById('add-keyword-btn');
@@ -1632,6 +1634,14 @@
             if (e.target.tagName === 'BUTTON') {
                 outlineButtons.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
                 e.target.classList.add('active');
+            }
+        });
+
+        categoryButtons.addEventListener('click', (e) => {
+            if (e.target.tagName === 'BUTTON') {
+                categoryButtons.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
+                e.target.classList.add('active');
+                planCategoryInput.value = e.target.dataset.value;
             }
         });
 


### PR DESCRIPTION
## Summary
- Show plan outline options as a single row of compact buttons
- Replace plan category dropdown with button-based selector
- Style and script updates to support new category button behavior

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4cf74620832e9d59c5b376ddcc62