### PR TITLE
Adjust bullet handling for specific plan sections

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1745,7 +1745,13 @@
                 outline.forEach((sec, idx) => {
                     switch (sec.type) {
                         case 'bullet':
-                            prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하고, 각 항목은 '~함' 또는 '~한다'와 같이 명료한 말투로 끝나며 두 가지 이상 세부 내용을 포함하세요.\n`;
+                            if (sec.title.includes('추진 배경') || sec.title.includes('방향') || sec.title.includes('방침')) {
+                                prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하고, 각 항목은 주제나 항목명을 쓰지 말고 바로 내용을 시작하여 '~함' 또는 '~한다'와 같이 명료한 말투로 끝나며 두 가지 이상 세부 내용을 포함하세요.\n`;
+                            } else if (sec.title.includes('추진 근거')) {
+                                prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 항목은 '법령', '관련 매뉴얼', '관련 지침', '교육청 지침' 네 가지로만 구성하고 각 항목마다 해당 근거를 간략히 서술하세요.\n`;
+                            } else {
+                                prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하고, 각 항목은 '~함' 또는 '~한다'와 같이 명료한 말투로 끝나며 두 가지 이상 세부 내용을 포함하세요.\n`;
+                            }
                             break;
                         case 'tablePlan':
                             prompt += `${idx + 1}.  **${sec.title}**: 소개 문장 없이 '1. 장소', '2. 일시', '3. 대상', '4. 프로그램' 번호를 붙여 각 항목에 대한 자세한 설명을 제공하세요. 이어서 동일한 항목을 포함한 Markdown 테이블을 추가하고, '프로그램' 칸은 불릿 리스트(-)로 세밀하게 작성하세요.\n`;
@@ -2197,9 +2203,16 @@ async function saveCurrentPlan() {
                 const isExpand = button.classList.contains('expand-btn');
                 const secTitle = sectionDiv.querySelector('h3').textContent;
                 const secMarkdown = sectionDiv.dataset.markdownContent;
-                const prompt = isExpand
-                    ? `다음 계획서 항목의 내용을 확장해줘. 기존의 불릿 리스트나 표 형식은 그대로 유지하되, 항목의 개수를 늘려줘. 자세한 설명을 추가하는 대신 새로운 불릿이나 표 행을 추가해줘.\n## ${secTitle}\n${secMarkdown}\n\n'## ${secTitle}' 형식의 마크다운으로 출력해줘.`
-                    : `다음 계획서 항목의 내용을 간소화해줘. 기존의 불릿 리스트나 표 형식은 그대로 유지하되, 항목의 개수를 줄여줘. 핵심 항목만 남겨줘.\n## ${secTitle}\n${secMarkdown}\n\n'## ${secTitle}' 형식의 마크다운으로 출력해줘.`;
+                let prompt;
+                if (isExpand) {
+                    if (secTitle.includes('추진 배경') || secTitle.includes('방향') || secTitle.includes('방침')) {
+                        prompt = `다음 계획서 항목의 내용을 확장해줘. 기존의 불릿 리스트는 그대로 유지하고 항목의 개수를 늘리지 말아줘. 대신 각 불릿의 설명을 더욱 구체적으로 작성해줘.\n## ${secTitle}\n${secMarkdown}\n\n'## ${secTitle}' 형식의 마크다운으로 출력해줘.`;
+                    } else {
+                        prompt = `다음 계획서 항목의 내용을 확장해줘. 기존의 불릿 리스트나 표 형식은 그대로 유지하되, 항목의 개수를 늘려줘. 자세한 설명을 추가하는 대신 새로운 불릿이나 표 행을 추가해줘.\n## ${secTitle}\n${secMarkdown}\n\n'## ${secTitle}' 형식의 마크다운으로 출력해줘.`;
+                    }
+                } else {
+                    prompt = `다음 계획서 항목의 내용을 간소화해줘. 기존의 불릿 리스트나 표 형식은 그대로 유지하되, 항목의 개수를 줄여줘. 핵심 항목만 남겨줘.\n## ${secTitle}\n${secMarkdown}\n\n'## ${secTitle}' 형식의 마크다운으로 출력해줘.`;
+                }
                 try {
                     showToast(isExpand ? '내용 늘리는 중입니다..' : '내용 줄이는 중입니다..');
                     const response = await fetch('/.netlify/functions/generatePlan', {


### PR DESCRIPTION
## Summary
- Avoid topic labels in background and direction bullets and limit grounds to four categories
- Expand or shrink section content with custom prompts for background and direction without adding bullets

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ae975c1b38832eb846eca987b86fb4