### PR TITLE
feat: support pdf-only plan examples with removal option

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,6 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.4.120/pdf.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/hwp.js@0.0.15/dist/hwp.min.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700&display=swap" rel="stylesheet">
@@ -166,7 +165,8 @@
                             <form id="plan-form" onsubmit="return false;">
                                 <div class="mb-4">
                                     <button type="button" id="example-upload-btn" class="w-full bg-blue-100 text-blue-700 font-medium py-1 px-2 rounded-md">예시 파일 업로드</button>
-                                    <input type="file" id="example-file-input" accept=".pdf,.hwp" class="hidden" />
+                                    <input type="file" id="example-file-input" accept=".pdf" multiple class="hidden" />
+                                    <div id="example-file-list" class="mt-2 space-y-1 text-sm text-gray-700"></div>
                                 </div>
                                 <div>
                                     <label class="block text-sm font-medium text-gray-700 mb-2">학교급</label>
@@ -516,7 +516,8 @@
 
         const exampleUploadBtn = document.getElementById('example-upload-btn');
         const exampleFileInput = document.getElementById('example-file-input');
-        let exampleData = null;
+        const exampleFileList = document.getElementById('example-file-list');
+        let exampleFiles = [];
 
         exampleUploadBtn.addEventListener('click', () => exampleFileInput.click());
 
@@ -531,45 +532,48 @@
             return text;
         }
 
-        async function extractHwpText(arrayBuffer) {
-            if (!window.HWP) throw new Error('HWP parser not available');
-            const doc = await HWP.read(new Uint8Array(arrayBuffer));
-            return doc.extractText();
-        }
-
         function extractOutline(text) {
             return text.split(/\r?\n/)
                        .map(l => l.trim())
                        .filter(l => /^\d+[\.\)]\s+/.test(l))
                        .map(l => l.replace(/^\d+[\.\)]\s+/, ''));
         }
+        function renderExampleFileList() {
+            exampleFileList.innerHTML = '';
+            exampleFiles.forEach(file => {
+                const item = document.createElement('div');
+                item.className = 'flex items-center';
+                item.dataset.name = file.name;
+                item.innerHTML = `<span class="flex-1 truncate">${file.name}</span><button type="button" class="remove-example ml-2 text-red-500 text-xs">제거</button>`;
+                exampleFileList.appendChild(item);
+            });
+        }
+
+        exampleFileList.addEventListener('click', (e) => {
+            if (e.target.classList.contains('remove-example')) {
+                const name = e.target.parentElement.dataset.name;
+                exampleFiles = exampleFiles.filter(f => f.name !== name);
+                renderExampleFileList();
+            }
+        });
 
         exampleFileInput.addEventListener('change', async (e) => {
-            const file = e.target.files[0];
-            if (!file) return;
+            const files = Array.from(e.target.files);
+            if (!files.length) return;
             try {
-                const arrayBuffer = await file.arrayBuffer();
-                let text = '';
-                const ext = file.name.split('.').pop().toLowerCase();
-                if (ext === 'pdf') {
-                    text = await extractPdfText(arrayBuffer);
-                } else if (ext === 'hwp') {
-                    text = await extractHwpText(arrayBuffer);
-                } else {
-                    throw new Error('지원되지 않는 형식');
+                for (const file of files) {
+                    const arrayBuffer = await file.arrayBuffer();
+                    const ext = file.name.split('.').pop().toLowerCase();
+                    if (ext !== 'pdf') {
+                        showToast('PDF 파일만 업로드 가능합니다.');
+                        continue;
+                    }
+                    const text = await extractPdfText(arrayBuffer);
+                    const outline = extractOutline(text);
+                    exampleFiles.push({ name: file.name, text, outline });
                 }
-                let outline = extractOutline(text);
-                if (outline.length === 0) outline = ['개요'];
-                exampleData = { text, outline };
-                schoolLevelButtons.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
-                outlineButtons.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
-                categoryButtons.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
-                planCategoryInput.value = '';
-                schoolLevelButtons.classList.add('pointer-events-none', 'opacity-50');
-                outlineButtons.classList.add('pointer-events-none', 'opacity-50');
-                categoryButtons.classList.add('pointer-events-none', 'opacity-50');
-                outlineDescription.textContent = `예시 파일 목차: ${outline.join(', ')}`;
-                categoryDescription.textContent = '예시 파일이 적용되어 분류 선택이 비활성화되었습니다.';
+                renderExampleFileList();
+                e.target.value = '';
                 showToast('예시 파일이 적용되었습니다.');
             } catch (err) {
                 console.error('Example file error:', err);
@@ -1806,11 +1810,8 @@
                                 .map(input => input.value.trim())
                                 .filter(Boolean);
             const currentYear = new Date().getFullYear();
-            let schoolLevel = '';
-            if (!exampleData) {
-                const activeSchool = schoolLevelButtons.querySelector('.active');
-                schoolLevel = activeSchool ? activeSchool.dataset.value : '';
-            }
+            const activeSchool = schoolLevelButtons.querySelector('.active');
+            const schoolLevel = activeSchool ? activeSchool.dataset.value : '';
 
             initialMessage.classList.add('hidden');
             resultSection.classList.add('hidden');
@@ -1822,73 +1823,64 @@
 
             try {
                 let prompt = '';
-                let outline = [];
-                if (exampleData) {
-                    outline = exampleData.outline.map(t => ({ title: t, type: 'bullet' }));
-                    prompt = `당신은 대한민국의 유능한 교사입니다. 다음 예시 자료의 문법, 내용, 목차 구조를 참고하여 '${planType}' 계획서를 작성해 주세요.\n\n`;
-                    prompt += `예시 자료 텍스트:\n${exampleData.text}\n\n`;
-                    prompt += `**출력 형식:**\n`;
-                    prompt += `- 전체 계획서의 제목은 'TITLE: [${currentYear+1}학년도 ${planType}]'과 같이 간결한 형식으로 첫 줄에 명시해 주세요.\n`;
-                    prompt += `- 내용은 반드시 다음 ${outline.length}개의 섹션으로 나누어 작성하고, 각 섹션 제목은 '## 1. ${outline[0].title}'과 같이 '##' 마크다운 헤더를 사용해야 합니다.\n`;
-                    prompt += `- 섹션 순서: ${outline.map((s, i) => `${i+1}. ${s.title}`).join(', ')}\n`;
-                    if (keywords.length) {
-                        prompt += `- 핵심 키워드: ${keywords.join(', ')}\n`;
-                    }
-                    prompt += `- **중요**: 생성하는 모든 텍스트에서 마크다운 굵은 글씨(**)를 사용하지 마세요. 모든 내용은 일반 텍스트로만 작성해주세요.`;
-                } else {
-                    const outlineName = outlineButtons.querySelector('.active').dataset.value;
-                    outline = planOutlineDefinitions[outlineName];
-                    const category = planCategoryInput.value;
-                    const focusInstruction = categoryFocus[category] || '';
-                    prompt = `당신은 대한민국의 유능한 교사입니다. 다음 조건에 맞춰 '${schoolLevel} ${planType}' 초안을 작성해 주세요.\n\n`;
-                    if (focusInstruction) {
-                        prompt += `- 분류: ${category}. ${focusInstruction}\n\n`;
-                    }
-                    if (planExamples) {
-                        prompt += `세부 추진 계획 작성 시 아래 예시를 참고하여 주제에 따라 유동적으로 구성해 주세요.\\n예시:\\n${planExamples}\\n\\n`;
-                    }
-                    prompt += `**출력 형식:**\n`;
-                    prompt += `- 전체 계획서의 제목은 'TITLE: [${currentYear+1}학년도 ${planType}]'과 같이 간결한 형식으로 첫 줄에 명시해 주세요.\n`;
-                    prompt += `- 내용은 반드시 다음 ${outline.length}개의 섹션으로 나누어 작성하고, 각 섹션 제목은 '## 1. ${outline[0].title}'과 같이 '##' 마크다운 헤더를 사용해야 합니다.\n`;
-                    prompt += `- 섹션 순서: ${outline.map((s, i) => `${i+1}. ${s.title}`).join(', ')}\n\n`;
-                    prompt += `**섹션별 작성 조건:**\n`;
-                    outline.forEach((sec, idx) => {
-                        switch (sec.type) {
-                            case 'bullet':
-                                if (sec.title.includes('추진 배경')) {
-                                    prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 최소 4개 이상의 항목을 포함하고, 각 항목은 주제나 항목명을 쓰지 말고 바로 내용을 시작하여 문장이 아닌 명사형 표현으로 '~요구', '~필요', '~증대', '~심화', '~대두' 등으로 끝나게 작성하세요.\n`;
-                                } else if (sec.title.includes('추진 목적')) {
-                                    prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 최소 4개 이상의 항목을 포함하고, 각 항목은 주제나 항목명을 쓰지 말고 바로 내용을 시작하여 '~실현', '~지원', '~구현', '~확대', '~강화' 등과 같은 명사형 표현으로 끝나게 작성하세요.\n`;
-                                } else if (sec.title.includes('기대효과') || sec.title.includes('기대 효과')) {
-                                    prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 아래 문장을 참고하여 교육적 기대 효과를 구체적으로 작성하고, 각 항목은 '~확대', '~강화', '~도모', '~증대' 등과 같은 명사형 표현으로 끝나게 하세요. 참고 문장: 창의력 사고력을 함양한다.; 배움 중심의 학습 문화를 확산한다.; 학교 내 소통과 협력 문화를 조성한다.; 학생 맞춤형 교육 기회를 마련한다.; 교사와 학생 간 상호작용을 활성화한다.; 교사의 전문성을 강화하여 교육력을 제고한다.; 교사와 학생의 업무 피로도를 감소시킨다.; 학교 폭력 및 갈등 요인을 근절한다.; 학부모와 학생의 만족도를 제고한다.\n`;
-                                } else if (sec.title.includes('방향')) {
-                                    prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 최소 4개 이상의 항목을 포함하고, 각 항목은 주제나 항목명을 쓰지 말고 바로 내용을 시작하여 '~정립', '~마련', '~추진', '~강화' 등과 같은 명사형 표현으로 끝나게 작성하세요.\n`;
-                                } else if (sec.title.includes('방침')) {
-                                    prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 최소 4개 이상의 항목을 포함하고, 각 항목은 주제나 항목명을 쓰지 말고 바로 내용을 시작하여 '~운영', '~구성', '~실시', '~지원' 등과 같은 명사형 표현으로 끝나게 작성하세요.\n`;
-                                } else if (sec.title.includes('근거')) {
-                                    prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 각 항목은 관련 법령·계획·조례 등의 제목과 문서 번호, 시행일 등을 괄호 안에 명시한 참고 문헌 형태로 작성하세요. 예시: - (변경)스마트기기 휴대 학습 「디벗 확대 계획」(중등교육과-13191, 2023. 3. 27.)\n`;
-                                } else {
-                                    prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 최소 4개 이상의 항목을 포함하고, 각 항목은 '~함' 또는 '~한다'와 같이 명료한 말투로 끝나며 두 가지 이상 세부 내용을 포함하세요.\n`;
-                                }
-                                break;
-                            case 'tablePlan':
-                                prompt += `${idx + 1}.  **${sec.title}**: 추진 과제를 번호 매긴 뒤 각 과제 아래에 '□ 추진업무', '○ 추진 방법', '○ 기관', '○ 기간(일정)', '○ 장소', '○ 수량/예산' 항목을 불릿으로 작성하고, 이어서 '추진 과제', '추진업무', '추진 방법', '기관', '기간', '장소', '수량/예산' 열을 포함한 Markdown 테이블을 추가하세요. 추진업무와 추진 방법에는 구체적인 프로그램명을 명시하세요.\n`;
-                                break;
-                            case 'tableBudget':
-                                prompt += `${idx + 1}.  **${sec.title}**: 예산 편성 방향을 짧게 서술하고, 이어서 '순', '사업명', '항목', '산출내역(원)', '예산액(천원)', '비고'를 포함한 Markdown 테이블을 제공하세요. '산출내역(원)'은 '200,000원 × 1대 × 1회'와 같이 곱셈 식으로 작성하세요.\n`;
-                                break;
-                            case 'tableSchedule':
-                                prompt += `${idx + 1}.  **${sec.title}**: 관련 내용을 간단히 설명하고, '월', '장소', '일시', '대상', '프로그램' 항목을 포함한 Markdown 테이블을 추가하세요. '프로그램' 항목은 각 프로그램의 명칭과 간단한 설명을 포함한 불릿 리스트(-) 형식으로 작성하고 최소 4개 이상의 항목을 포함하세요.\n`;
-                                break;
-                            default:
-                                prompt += `${idx + 1}.  **${sec.title}**: 계획의 핵심 내용을 구체적으로 서술하세요.\n`;
-                        }
-                    });
-                    prompt += `- **핵심 키워드**: '${keywords.join(', ')}'를 계획서 전반에 자연스럽게 반영해주세요.\n`;
-                    prompt += `- 모든 불릿 리스트는 최소 4개 이상의 항목을 포함해야 합니다.\n`;
-                    prompt += `- '추진 배경', '추진 목적', '기대효과', '추진 방향', '추진 방침' 항목은 문장이 아닌 명사형 표현으로 작성하고, 그 밖의 항목은 공손한 표현을 사용하지 말고 '~함' 또는 '~한다'와 같이 서술형으로 작성하세요.\n`;
-                    prompt += `- **중요**: 생성하는 모든 텍스트에서 마크다운 굵은 글씨(**)를 사용하지 마세요. 모든 내용은 일반 텍스트로만 작성해주세요.`;
+                const outlineName = outlineButtons.querySelector('.active').dataset.value;
+                const outline = planOutlineDefinitions[outlineName];
+                const category = planCategoryInput.value;
+                const focusInstruction = categoryFocus[category] || '';
+                prompt = `당신은 대한민국의 유능한 교사입니다. 다음 조건에 맞춰 '${schoolLevel} ${planType}' 초안을 작성해 주세요.\n\n`;
+                if (focusInstruction) {
+                    prompt += `- 분류: ${category}. ${focusInstruction}\n\n`;
                 }
+                if (planExamples) {
+                    prompt += `세부 추진 계획 작성 시 아래 예시를 참고하여 주제에 따라 유동적으로 구성해 주세요.\\n예시:\\n${planExamples}\\n\\n`;
+                }
+                if (exampleFiles.length) {
+                    prompt += `다음 예시 자료의 문법과 내용을 참고하여 작성해 주세요.\\n`;
+                    exampleFiles.forEach((file, idx) => {
+                        prompt += `예시 ${idx + 1} (${file.name}):\\n${file.text}\\n\\n`;
+                    });
+                }
+                prompt += `**출력 형식:**\n`;
+                prompt += `- 전체 계획서의 제목은 'TITLE: [${currentYear+1}학년도 ${planType}]'과 같이 간결한 형식으로 첫 줄에 명시해 주세요.\n`;
+                prompt += `- 내용은 반드시 다음 ${outline.length}개의 섹션으로 나누어 작성하고, 각 섹션 제목은 '## 1. ${outline[0].title}'과 같이 '##' 마크다운 헤더를 사용해야 합니다.\n`;
+                prompt += `- 섹션 순서: ${outline.map((s, i) => `${i+1}. ${s.title}`).join(', ')}\n\n`;
+                prompt += `**섹션별 작성 조건:**\n`;
+                outline.forEach((sec, idx) => {
+                    switch (sec.type) {
+                        case 'bullet':
+                            if (sec.title.includes('추진 배경')) {
+                                prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 최소 4개 이상의 항목을 포함하고, 각 항목은 주제나 항목명을 쓰지 말고 바로 내용을 시작하여 문장이 아닌 명사형 표현으로 '~요구', '~필요', '~증대', '~심화', '~대두' 등으로 끝나게 작성하세요.\\n`;
+                            } else if (sec.title.includes('추진 목적')) {
+                                prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 최소 4개 이상의 항목을 포함하고, 각 항목은 주제나 항목명을 쓰지 말고 바로 내용을 시작하여 '~실현', '~지원', '~구현', '~확대', '~강화' 등과 같은 명사형 표현으로 끝나게 작성하세요.\\n`;
+                            } else if (sec.title.includes('기대효과') || sec.title.includes('기대 효과')) {
+                                prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 아래 문장을 참고하여 교육적 기대 효과를 구체적으로 작성하고, 각 항목은 '~확대', '~강화', '~도모', '~증대' 등과 같은 명사형 표현으로 끝나게 하세요. 참고 문장: 창의력 사고력을 함양한다.; 배움 중심의 학습 문화를 확산한다.; 학교 내 소통과 협력 문화를 조성한다.; 학생 맞춤형 교육 기회를 마련한다.; 교사와 학생 간 상호작용을 활성화한다.; 교사의 전문성을 강화하여 교육력을 제고한다.; 교사와 학생의 업무 피로도를 감소시킨다.; 학교 폭력 및 갈등 요인을 근절한다.; 학부모와 학생의 만족도를 제고한다.\\n`;
+                            } else if (sec.title.includes('방향')) {
+                                prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 최소 4개 이상의 항목을 포함하고, 각 항목은 주제나 항목명을 쓰지 말고 바로 내용을 시작하여 '~정립', '~마련', '~추진', '~강화' 등과 같은 명사형 표현으로 끝나게 작성하세요.\\n`;
+                            } else if (sec.title.includes('방침')) {
+                                prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 최소 4개 이상의 항목을 포함하고, 각 항목은 주제나 항목명을 쓰지 말고 바로 내용을 시작하여 '~운영', '~구성', '~실시', '~지원' 등과 같은 명사형 표현으로 끝나게 작성하세요.\\n`;
+                            } else if (sec.title.includes('근거')) {
+                                prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 각 항목은 관련 법령·계획·조례 등의 제목과 문서 번호, 시행일 등을 괄호 안에 명시한 참고 문헌 형태로 작성하세요. 예시: - (변경)스마트기기 휴대 학습 「디벗 확대 계획」(중등교육과-13191, 2023. 3. 27.)\\n`;
+                            } else {
+                                prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 최소 4개 이상의 항목을 포함하고, 각 항목은 '~함' 또는 '~한다'와 같이 명료한 말투로 끝나며 두 가지 이상 세부 내용을 포함하세요.\\n`;
+                            }
+                            break;
+                        case 'tablePlan':
+                            prompt += `${idx + 1}.  **${sec.title}**: 추진 과제를 번호 매긴 뒤 각 과제 아래에 '□ 추진업무', '○ 추진 방법', '○ 기관', '○ 기간(일정)', '○ 장소', '○ 수량/예산' 항목을 불릿으로 작성하고, 이어서 '추진 과제', '추진업무', '진 방법', '기관', '기간', '장소', '수량/예산' 열을 포함한 Markdown 테이블을 추가하세요. 추진업무와 추진 방법에는 구체적인 프로그램명을 명시하세요.\\n`;
+                            break;
+                        case 'tableBudget':
+                            prompt += `${idx + 1}.  **${sec.title}**: 예산 편성 방향을 짧게 서술하고, 이어서 '순', '사업명', '항목', '산출내역(원)', '예산액(천원)', '비고'를 포함한 Markdown 테이블을 제공하세요. '산출내역(원)'은 '200,000원 × 1대 × 1회'와 같이 곱셈 식으로 작성하세요.\\n`;
+                            break;
+                        case 'tableSchedule':
+                            prompt += `${idx + 1}.  **${sec.title}**: 관련 내용을 간단히 설명하고, '월', '장소', '일시', '대상', '프로그램' 항목을 포함한 Markdown 테이블을 추가하세요. '프로그램' 항목은 각 프로그램의 명칭과 간단한 설명을 포함한 불릿 리스트(-) 형식으로 작성하고 최소 4개 이상의 항목을 포함하세요.\\n`;
+                            break;
+                        default:
+                            prompt += `${idx + 1}.  **${sec.title}**: 계획의 핵심 내용을 구체적으로 서술하세요.\\n`;
+                    }
+                });
+                prompt += `- **핵심 키워드**: '${keywords.join(', ')}'를 계획서 전반에 자연스럽게 반영해주세요.\\n`;
+                prompt += `- 모든 불릿 리스트는 최소 4개 이상의 항목을 포함해야 합니다.\\n`;
+                prompt += `- '추진 배경', '추진 목적', '기대효과', '추진 방향', '추진 방침' 항목은 문장이 아닌 명사형 표현으로 작성하고, 그 밖의 항목은 공손한 표현을 사용하지 말고 '~함' 또는 '~한다'와 같이 서술형으로 작성하세요.\\n`;
+                prompt += `- **중요**: 생성하는 모든 텍스트에서 마크다운 굵은 글씨(**)를 사용하지 마세요. 모든 내용은 일반 텍스트로만 작성해주세요.`;
 
                 const apiUrl = `/.netlify/functions/generatePlan`;
                 


### PR DESCRIPTION
## Summary
- Disallow HWP uploads and allow multiple PDF example files for plan creation
- Keep school level, outline, and category selectable while referencing uploaded PDFs
- Generate plan text using uploaded examples and allow removing any sample

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7ebe5e3a8832e816057389797e04a