### PR TITLE
Handle section splits without space after headings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1989,7 +1989,7 @@
             
             planContainer.innerHTML = '';
 
-            const sections = content.split(/^##\s/m).filter(s => s.trim() !== '');
+            const sections = content.split(/^##\s*/m).filter(s => s.trim() !== '');
             const sectionTitles = [];
 
             sections.forEach(sectionText => {


### PR DESCRIPTION
## Summary
- Ensure plan sections split correctly even when `##` headings are not followed by a space

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b821cf6a0c832e8d7e6eb5966cc70c