### PR TITLE
Persist detailed plans and split copy actions

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -54,7 +54,7 @@
         .plan-section-content td { border: 1px solid #cbd5e1; padding: 0.75rem; text-align: left; }
         .plan-section-content td { white-space: pre-line; }
         .plan-section-content th { background-color: #f1f5f9; font-weight: 600; }
-        .edit-btn, .copy-section-btn, .expand-btn, .detail-btn, .generate-detail-btn, .regenerate-detail-btn, .regenerate-section-btn {
+        .edit-btn, .copy-section-btn, .copy-table-btn, .expand-btn, .detail-btn, .generate-detail-btn, .regenerate-detail-btn, .regenerate-section-btn {
             background-color: #e2e8f0;
             color: #475569;
             border: none;
@@ -65,7 +65,7 @@
             cursor: pointer;
             transition: background-color 0.2s;
         }
-        .edit-btn:hover, .copy-section-btn:hover, .expand-btn:hover, .detail-btn:hover, .generate-detail-btn:hover, .regenerate-detail-btn:hover, .regenerate-section-btn:hover { background-color: #cbd5e1; }
+        .edit-btn:hover, .copy-section-btn:hover, .copy-table-btn:hover, .expand-btn:hover, .detail-btn:hover, .generate-detail-btn:hover, .regenerate-detail-btn:hover, .regenerate-section-btn:hover { background-color: #cbd5e1; }
         .loader { border: 4px solid #f3f3f3; border-top: 4px solid #7A9D54; border-radius: 50%; width: 40px; height: 40px; animation: spin 1s linear infinite; }
         @keyframes spin { 0% { transform: rotate(0deg); } 100% { transform: rotate(360deg); } }
         .nav-link { padding: 0.5rem 1rem; border-radius: 0.375rem; transition: background-color 0.2s, color 0.2s; }
@@ -1965,14 +1965,52 @@
                 contentDiv.className = 'plan-section-content';
 
                 if (sectionTitle.includes('세부 추진 계획')) {
-                    sectionDiv.dataset.markdownContent = '';
-                    const generateBtn = document.createElement('button');
-                    generateBtn.className = 'generate-detail-btn';
-                    generateBtn.textContent = '생성';
-                    contentDiv.appendChild(generateBtn);
+                    if (sectionContentMarkdown) {
+                        sectionDiv.dataset.markdownContent = sectionContentMarkdown;
+                        contentDiv.innerHTML = parseMarkdown(sectionContentMarkdown);
+                        addTableCopyButtons(contentDiv);
+
+                        const controlsDiv = document.createElement('div');
+                        controlsDiv.className = 'absolute top-4 right-4 flex gap-2';
+
+                        const regenBtn = document.createElement('button');
+                        regenBtn.className = 'regenerate-detail-btn';
+                        regenBtn.textContent = '재생성';
+
+                        const expandBtn = document.createElement('button');
+                        expandBtn.className = 'expand-btn';
+                        expandBtn.textContent = '내용 늘리기';
+
+                        const detailBtn = document.createElement('button');
+                        detailBtn.className = 'detail-btn';
+                        detailBtn.textContent = '자세하게';
+
+                        const editBtn = document.createElement('button');
+                        editBtn.className = 'edit-btn';
+                        editBtn.textContent = '편집';
+
+                        const copyBtn = document.createElement('button');
+                        copyBtn.className = 'copy-section-btn';
+                        copyBtn.textContent = '복사';
+
+                        controlsDiv.appendChild(regenBtn);
+                        controlsDiv.appendChild(expandBtn);
+                        controlsDiv.appendChild(detailBtn);
+                        controlsDiv.appendChild(editBtn);
+                        controlsDiv.appendChild(copyBtn);
+
+                        sectionDiv.appendChild(controlsDiv);
+                    } else {
+                        sectionDiv.dataset.markdownContent = '';
+                        const generateBtn = document.createElement('button');
+                        generateBtn.className = 'generate-detail-btn';
+                        generateBtn.textContent = '생성';
+                        contentDiv.appendChild(generateBtn);
+                    }
                 } else {
                     sectionDiv.dataset.markdownContent = sectionContentMarkdown;
                     contentDiv.innerHTML = parseMarkdown(sectionContentMarkdown);
+                    addTableCopyButtons(contentDiv);
 
                     const controlsDiv = document.createElement('div');
                     controlsDiv.className = 'absolute top-4 right-4 flex gap-2';
@@ -2108,6 +2146,16 @@
             document.execCommand('copy');
             document.removeEventListener('copy', listener);
             showToast(isHtml ? '표(HTML)가 클립보드에 복사되었습니다.' : '내용이 클립보드에 복사되었습니다.');
+        }
+
+        function addTableCopyButtons(container) {
+            container.querySelectorAll('table').forEach(table => {
+                if (table.previousElementSibling && table.previousElementSibling.classList && table.previousElementSibling.classList.contains('copy-table-btn')) return;
+                const btn = document.createElement('button');
+                btn.className = 'copy-table-btn';
+                btn.textContent = '표 복사';
+                table.parentNode.insertBefore(btn, table);
+            });
         }
 
         function showToast(message) {
@@ -2282,6 +2330,7 @@ async function saveCurrentPlan() {
                         newContent = removeBudgetInfo(newContent);
                         sectionDiv.dataset.markdownContent = newContent;
                         contentDiv.innerHTML = parseMarkdown(newContent);
+                        addTableCopyButtons(contentDiv);
 
                         const oldControls = sectionDiv.querySelector('.absolute.top-4.right-4');
                         if (oldControls) oldControls.remove();
@@ -2358,18 +2407,21 @@ async function saveCurrentPlan() {
                         let newContent = lines.join('\n').trim();
                         sectionDiv.dataset.markdownContent = newContent;
                         contentDiv.innerHTML = parseMarkdown(newContent);
+                        addTableCopyButtons(contentDiv);
                         await saveCurrentPlan();
                     }
                 } catch (err) {
                     console.error('Section Regenerate Error:', err);
                 }
             } else if (button.classList.contains('copy-section-btn')) {
-                const markdownContent = sectionDiv.dataset.markdownContent;
-                if (markdownContent.includes('|')) {
-                    const htmlToCopy = markdownTableToHtmlClipboard(markdownContent);
-                    copyToClipboard(htmlToCopy, true);
-                } else {
-                    copyToClipboard(contentDiv.innerText, false);
+                const tempDiv = contentDiv.cloneNode(true);
+                tempDiv.querySelectorAll('table').forEach(t => t.remove());
+                copyToClipboard(tempDiv.innerText.trim(), false);
+            } else if (button.classList.contains('copy-table-btn')) {
+                let table = button.nextElementSibling;
+                if (!table || table.tagName !== 'TABLE') table = button.previousElementSibling;
+                if (table && table.tagName === 'TABLE') {
+                    copyToClipboard(table.outerHTML, true);
                 }
             } else if (button.classList.contains('edit-btn')) {
                 if (button.textContent === '편집') { // Start editing
@@ -2389,6 +2441,7 @@ async function saveCurrentPlan() {
                     const newContentDiv = document.createElement('div');
                     newContentDiv.className = 'plan-section-content';
                     newContentDiv.innerHTML = parseMarkdown(newMarkdown);
+                    addTableCopyButtons(newContentDiv);
                     textarea.replaceWith(newContentDiv);
                     saveCurrentPlan();
                 }
@@ -2458,6 +2511,7 @@ async function saveCurrentPlan() {
                         newContent = removeBudgetInfo(newContent);
                         sectionDiv.dataset.markdownContent = newContent;
                         contentDiv.innerHTML = parseMarkdown(newContent);
+                        addTableCopyButtons(contentDiv);
                         await saveCurrentPlan();
                     }
                 } catch (err) {
@@ -2478,8 +2532,7 @@ async function saveCurrentPlan() {
                 const popup = window.open('', '_blank', 'width=800,height=600,scrollbars=yes');
                 if (popup) {
                     const html = parseMarkdown(markdown);
-                    const markdownForScript = JSON.stringify(markdown);
-                    popup.document.write(`<!DOCTYPE html><html lang="ko"><head><meta charset="UTF-8"><title>${planTitle.textContent}</title><style>body{font-family:'Noto Sans KR',sans-serif;padding:1rem;} table{width:100%;border-collapse:collapse;} th,td{border:1px solid #cbd5e1;padding:0.75rem;text-align:left;} th{background-color:#f1f5f9;font-weight:600;}</style></head><body><button id="copyTextBtn">복사</button><div id="content">${html}</div><script>const markdown=${markdownForScript};document.getElementById('copyTextBtn').addEventListener('click',function(){navigator.clipboard.writeText(markdown).then(()=>alert('내용이 복사되었습니다.'));});<\/script></body></html>`);
+                    popup.document.write(`<!DOCTYPE html><html lang="ko"><head><meta charset="UTF-8"><title>${planTitle.textContent}</title><style>body{font-family:'Noto Sans KR',sans-serif;padding:1rem;} table{width:100%;border-collapse:collapse;} th,td{border:1px solid #cbd5e1;padding:0.75rem;text-align:left;} th{background-color:#f1f5f9;font-weight:600;}</style></head><body><button id="copyTextBtn">텍스트 복사</button><div id="content">${html}</div><script>const textOnly=(()=>{const c=document.getElementById('content').cloneNode(true);c.querySelectorAll('table').forEach(t=>t.remove());return c.innerText.trim();})();document.getElementById('copyTextBtn').addEventListener('click',function(){navigator.clipboard.writeText(textOnly).then(()=>alert('내용이 복사되었습니다.'));});function copyTable(tbl){navigator.clipboard.write([new ClipboardItem({'text/html':new Blob([tbl.outerHTML],{type:'text/html'}),'text/plain':new Blob([tbl.innerText],{type:'text/plain'})})]).then(()=>alert('표가 복사되었습니다.'));}document.querySelectorAll('table').forEach(t=>{const b=document.createElement('button');b.textContent='표 복사';b.addEventListener('click',()=>copyTable(t));t.parentNode.insertBefore(b,t);});<\/script></body></html>`);
                     popup.document.close();
                 }
             });


### PR DESCRIPTION
## Summary
- ensure saved detail plans load with full content instead of showing a blank "generate" button
- add table-only copy buttons and make section copy copy text only; duplicate these features in the summary popup

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9871c3224832e9c6256724376421b