### PR TITLE
Ensure plan table copy preserves styles

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2110,6 +2110,24 @@
             return tableHtml;
         }
 
+        function htmlTableToHtmlClipboard(table) {
+            const clone = table.cloneNode(true);
+            clone.style.borderCollapse = 'collapse';
+            clone.style.width = '100%';
+            clone.style.border = '1px solid black';
+            clone.querySelectorAll('th').forEach(th => {
+                th.style.border = '1px solid black';
+                th.style.padding = '8px';
+                th.style.backgroundColor = '#f2f2f2';
+                th.style.textAlign = 'center';
+            });
+            clone.querySelectorAll('td').forEach(td => {
+                td.style.border = '1px solid black';
+                td.style.padding = '8px';
+            });
+            return clone.outerHTML;
+        }
+
         function removeBudgetInfo(markdown) {
             const rows = markdown.split('\n');
             if (rows[0] && rows[0].includes('|')) {
@@ -2421,7 +2439,8 @@ async function saveCurrentPlan() {
                 let table = button.nextElementSibling;
                 if (!table || table.tagName !== 'TABLE') table = button.previousElementSibling;
                 if (table && table.tagName === 'TABLE') {
-                    copyToClipboard(table.outerHTML, true);
+                    const htmlToCopy = htmlTableToHtmlClipboard(table);
+                    copyToClipboard(htmlToCopy, true);
                 }
             } else if (button.classList.contains('edit-btn')) {
                 if (button.textContent === '편집') { // Start editing


### PR DESCRIPTION
## Summary
- Add `htmlTableToHtmlClipboard` to replicate styled table copying.
- Use styled HTML when copying plan tables to keep formatting consistent with table generator.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b98a33d934832eb57211ffc5692755