### PR TITLE
feat: migrate to Next.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,11 +4,17 @@
   "description": "Serverless functions for Aiedu Teacher",
   "main": "index.js",
   "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "node-fetch": "^2.6.7"
+    "node-fetch": "^2.6.7",
+    "next": "^14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
   }
 }

--- a/pages/api/generatePlan.js
+++ b/pages/api/generatePlan.js
@@ -1,0 +1,39 @@
+import fetch from 'node-fetch';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).send('Method Not Allowed');
+    return;
+  }
+
+  try {
+    const { prompt } = req.body;
+    const apiKey = process.env.GEMINI_API_KEY;
+
+    if (!prompt) {
+      res.status(400).json({ error: 'Prompt is required.' });
+      return;
+    }
+
+    const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${apiKey}`;
+    const response = await fetch(apiUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] })
+    });
+
+    if (!response.ok) {
+      const errorBody = await response.json();
+      console.error('Gemini API Error:', errorBody);
+      res.status(response.status).json(errorBody);
+      return;
+    }
+
+    const result = await response.json();
+    res.status(200).json(result);
+  } catch (error) {
+    console.error('Internal Server Error:', error);
+    res.status(500).json({ error: 'Internal Server Error' });
+  }
+}
+

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,16 @@
+import Head from 'next/head';
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>Aiedu Teacher</title>
+      </Head>
+      <main>
+        <h1>Welcome to the Next.js version of Aiedu Teacher</h1>
+        <p>The site has been migrated to use React and Next.js. Add your components here.</p>
+      </main>
+    </>
+  );
+}
+


### PR DESCRIPTION
## Summary
- set up Next.js with React for the project
- add API route wrapping existing generatePlan function

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68ba27070a50832e8802ce93717ace02