### PR TITLE
Add Excalidraw sketchbook page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.next/

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@excalidraw/excalidraw": "^0.17.7",
     "node-fetch": "^2.6.7",
     "next": "^14.2.3",
     "react": "^18.2.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,0 +1,5 @@
+import '@excalidraw/excalidraw/dist/excalidraw.min.css';
+
+export default function MyApp({ Component, pageProps }) {
+  return <Component {...pageProps} />;
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import Head from 'next/head';
+import Link from 'next/link';
 
 export default function Home() {
   return (
@@ -9,6 +10,9 @@ export default function Home() {
       <main>
         <h1>Welcome to the Next.js version of Aiedu Teacher</h1>
         <p>The site has been migrated to use React and Next.js. Add your components here.</p>
+        <p>
+          <Link href="/sketchbook">Go to 에이두 스케치북</Link>
+        </p>
       </main>
     </>
   );

--- a/pages/sketchbook.js
+++ b/pages/sketchbook.js
@@ -1,0 +1,77 @@
+import { useCallback, useMemo, useRef } from 'react';
+import dynamic from 'next/dynamic';
+import Head from 'next/head';
+
+const Excalidraw = dynamic(
+  async () => (await import('@excalidraw/excalidraw')).Excalidraw,
+  { ssr: false }
+);
+
+export default function Sketchbook() {
+  const apiRef = useRef(null);
+
+  const initialData = useMemo(() => {
+    if (typeof window === 'undefined') return undefined;
+    const saved = localStorage.getItem('my-excalidraw-scene');
+    return saved ? JSON.parse(saved) : undefined;
+  }, []);
+
+  const onChange = useCallback((elements, appState, files) => {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(
+      'my-excalidraw-scene',
+      JSON.stringify({ elements, appState, files })
+    );
+  }, []);
+
+  const exportPNG = useCallback(async () => {
+    if (!apiRef.current) return;
+    const { exportToBlob } = await import('@excalidraw/excalidraw');
+    const elements = apiRef.current.getSceneElements();
+    const appState = apiRef.current.getAppState();
+    const files = apiRef.current.getFiles();
+    const blob = await exportToBlob({ elements, appState, files });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = (appState.name || 'excalidraw') + '.png';
+    a.click();
+    URL.revokeObjectURL(url);
+  }, []);
+
+  return (
+    <>
+      <Head>
+        <title>에이두 스케치북</title>
+      </Head>
+      <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
+        <div style={{ padding: 8, borderBottom: '1px solid #eee' }}>
+          <button onClick={exportPNG}>PNG로 저장</button>
+          <label style={{ marginLeft: 8 }}>
+            <input
+              type="file"
+              accept=".excalidraw,application/json"
+              hidden
+              onChange={async (e) => {
+                const file = e.target.files?.[0];
+                if (!file || !apiRef.current) return;
+                const text = await file.text();
+                const data = JSON.parse(text);
+                apiRef.current.updateScene(data);
+              }}
+            />
+            JSON 불러오기
+          </label>
+        </div>
+        <div style={{ flex: 1 }}>
+          <Excalidraw
+            ref={apiRef}
+            initialData={initialData}
+            onChange={onChange}
+            UIOptions={{ canvasActions: { toggleTheme: true } }}
+          />
+        </div>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate Excalidraw sketchbook page with PNG export and JSON import
- link sketchbook from home page
- set up global Excalidraw styles and ignore Next.js build artifacts

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build` (fails: Module not found: Can't resolve '@excalidraw/excalidraw')

------
https://chatgpt.com/codex/tasks/task_e_68ba308bec40832eb6413292cd6aa7a8