### PR TITLE
Align plan editing names and sentence style

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -161,7 +161,7 @@
                 <div id="plan-view" class="hidden">
                     <div class="flex flex-col lg:flex-row gap-6">
                         <aside class="w-full lg:w-1/3 bg-white p-6 rounded-lg shadow-lg h-fit lg:sticky top-24">
-                            <h3 class="text-lg font-semibold mb-4">입력 테이블</h3>
+                            <h3 class="text-lg font-semibold mb-4">메뉴얼, 지침 입력 테이블</h3>
                             <form id="plan-form" onsubmit="return false;">
                                 <div class="mb-4">
                                     <button type="button" id="example-upload-btn" class="w-full bg-blue-100 text-blue-700 font-medium py-1 px-2 rounded-md">예시 파일 업로드</button>
@@ -219,7 +219,7 @@
                                 <button type="submit" id="generate-btn" class="w-full bg-[#7A9D54] text-white font-bold py-3 px-4 rounded-lg hover:bg-[#6a8a4a] flex items-center justify-center">AI 운영계획서 생성</button>
                             </form>
                             <div class="bg-white p-6 rounded-lg shadow hidden" id="plan-modify-section">
-                                <h3 class="text-lg font-semibold mb-2">수정 테이블</h3>
+                                <h3 class="text-lg font-semibold mb-2">세부 추진 계획 수정 테이블</h3>
                                 <p class="text-sm text-gray-600 mb-4">수정하고자 하는 목차를 변경 목차에서 정하고, 수정 내용을 작성 후 엔터를 눌러보세요.</p>
                                 <form id="plan-modify-form" class="space-y-4">
                                     <div>
@@ -236,7 +236,7 @@
                                 </form>
                             </div>
                             <div class="mt-8">
-                                <h3 class="text-lg font-bold mb-4 border-b pb-2">목록 테이블</h3>
+                                <h3 class="text-lg font-bold mb-4 border-b pb-2">이전 계획서 작성 목록</h3>
                                 <div id="plan-saved-list" class="space-y-3 max-h-60 overflow-y-auto">
                                     <!-- Recent plans will be dynamically inserted here -->
                                 </div>
@@ -1853,7 +1853,7 @@
                             } else if (sec.title.includes('근거')) {
                                 prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 각 항목은 관련 법령·계획·조례 등의 제목과 문서 번호, 시행일 등을 괄호 안에 명시한 참고 문헌 형태로 작성하세요. 예시: - (변경)스마트기기 휴대 학습 「디벗 확대 계획」(중등교육과-13191, 2023. 3. 27.)\\n`;
                             } else {
-                                prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 최소 4개 이상의 항목을 포함하고, 각 항목은 '~함' 또는 '~한다'와 같이 명료한 말투로 끝나며 두 가지 이상 세부 내용을 포함하세요.\\n`;
+                                prompt += `${idx + 1}.  **${sec.title}**: 불릿 리스트(-) 형식으로 작성하되, 최소 4개 이상의 항목을 포함하고, 각 항목은 '~한다.'로 끝나는 명료한 문장으로 작성하며 두 가지 이상 세부 내용을 포함하세요.\\n`;
                             }
                             break;
                         case 'tablePlan':
@@ -1875,7 +1875,7 @@
                 });
                 prompt += `- **핵심 키워드**: '${keywords.join(', ')}'를 계획서 전반에 자연스럽게 반영해주세요.\\n`;
                 prompt += `- 모든 불릿 리스트는 최소 4개 이상의 항목을 포함해야 합니다.\\n`;
-                prompt += `- '추진 배경', '추진 목적', '기대효과', '추진 방향', '추진 방침' 항목은 문장이 아닌 명사형 표현으로 작성하고, 그 밖의 항목은 공손한 표현을 사용하지 말고 '~함' 또는 '~한다'와 같이 서술형으로 작성하세요.\\n`;
+                prompt += `- '추진 배경', '추진 목적', '기대효과', '추진 방향', '추진 방침' 항목은 문장이 아닌 명사형 표현으로 작성하고, 그 밖의 항목은 공손한 표현을 사용하지 말고 모두 '~한다.'로 끝나는 서술형으로 작성하세요.\\n`;
                 prompt += `- **중요**: 생성하는 모든 텍스트에서 마크다운 굵은 글씨(**)를 사용하지 마세요. 모든 내용은 일반 텍스트로만 작성해주세요.`;
 
                 const apiUrl = `/.netlify/functions/generatePlan`;
@@ -1941,7 +1941,12 @@
                 const lines = sectionText.trim().split('\n');
                 const sectionTitle = lines.shift().trim();
                 sectionTitles.push(sectionTitle);
-                const sectionContentMarkdown = lines.join('\n').trim();
+                let sectionContentMarkdown = lines.join('\n').trim();
+                sectionContentMarkdown = sectionContentMarkdown
+                    .replace(/합니다\./gm, '한다.')
+                    .replace(/합니다$/gm, '한다')
+                    .replace(/함\./gm, '한다.')
+                    .replace(/함$/gm, '한다');
 
                 const sectionDiv = document.createElement('div');
                 sectionDiv.className = 'plan-section';
@@ -2047,6 +2052,10 @@
                     opt.textContent = title;
                     planModifyTarget.appendChild(opt);
                 });
+                const detailOption = Array.from(planModifyTarget.options).find(opt => opt.value.includes('세부 추진 계획'));
+                if (detailOption) {
+                    planModifyTarget.value = detailOption.value;
+                }
             }
 
             loadingIndicator.style.display = 'none';
@@ -2232,7 +2241,12 @@ async function saveCurrentPlan() {
                             if (section) {
                                 const lines = markdown.split('\n');
                                 if (lines[0].startsWith('##')) lines.shift();
-                                const newContent = lines.join('\n').trim();
+                                let newContent = lines.join('\n').trim();
+                                newContent = newContent
+                                    .replace(/합니다\./gm, '한다.')
+                                    .replace(/합니다$/gm, '한다')
+                                    .replace(/함\./gm, '한다.')
+                                    .replace(/함$/gm, '한다');
                                 section.dataset.markdownContent = newContent;
                                 const contentDiv = section.querySelector('.plan-section-content');
                                 contentDiv.innerHTML = parseMarkdown(newContent);
@@ -2332,7 +2346,7 @@ async function saveCurrentPlan() {
                         const lines = markdown.split('\n');
                         if (lines[0].startsWith('##')) lines.shift();
                         let newContent = lines.join('\n').trim();
-                        newContent = newContent.replace(/합니다\./gm, '한다.').replace(/합니다$/gm, '한다');
+                        newContent = newContent.replace(/합니다\./gm, '한다.').replace(/합니다$/gm, '한다').replace(/함\./gm, '한다.').replace(/함$/gm, '한다');
                         newContent = removeBudgetInfo(newContent);
                         sectionDiv.dataset.markdownContent = newContent;
                         contentDiv.innerHTML = parseMarkdown(newContent);
@@ -2513,7 +2527,7 @@ async function saveCurrentPlan() {
                         if (lines[0].startsWith('##')) lines.shift();
                         let newContent = lines.join('\n').trim();
                         if (!secTitle.includes('추진 배경') && !secTitle.includes('추진 목적') && !secTitle.includes('기대효과') && !secTitle.includes('방향') && !secTitle.includes('방침')) {
-                            newContent = newContent.replace(/합니다\./gm, '한다.').replace(/합니다$/gm, '한다');
+                            newContent = newContent.replace(/합니다\./gm, '한다.').replace(/합니다$/gm, '한다').replace(/함\./gm, '한다.').replace(/함$/gm, '한다');
                         }
                         newContent = removeBudgetInfo(newContent);
                         sectionDiv.dataset.markdownContent = newContent;


### PR DESCRIPTION
## Summary
- Rename plan view tables to reference manuals and prior plans
- Default plan modification to the detailed plan section
- Normalize generated sentences to end with '~한다.' regardless of outline

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c80a40d948832ea0c6bf3586b51640