### PR TITLE
Ensure detailed outline ordering and refine summary prompt

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1758,12 +1758,7 @@
                 outlineButtons.querySelectorAll('button').forEach(btn => btn.classList.remove('active'));
                 e.target.classList.add('active');
                 if (e.target.dataset.value === '세부목차') {
-                    const baseTitles = planOutlineDefinitions["기본목차"].map(s => s.title);
-                    const detailTitles = planOutlineDefinitions["세부목차"].map(s => s.title);
-                    currentOutline = planOutlineDefinitions["기본목차"].filter(s => detailTitles.includes(s.title));
-                    planOutlineDefinitions["세부목차"].forEach(sec => {
-                        if (!baseTitles.includes(sec.title)) currentOutline.push(sec);
-                    });
+                    currentOutline = [...planOutlineDefinitions["세부목차"]];
                 } else {
                     currentOutline = [...planOutlineDefinitions["기본목차"]];
                 }
@@ -2566,7 +2561,7 @@ async function saveCurrentPlan() {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({
-                            prompt: `다음 계획서 내용을 A4 한 장 분량으로 요약해줘.\n\n${markdown}`
+                            prompt: `다음 계획서 내용을 A4용지 한 장에 들어갈 분량으로 요약해줘.\n\n${markdown}`
                         })
                     });
                     const result = await response.json();


### PR DESCRIPTION
## Summary
- Use exact detailed outline order when selecting the detailed outline option.
- Summaries now request output sized for a single A4 page.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c81846543c832eb99ede45779b1138