### PR TITLE
Update default Gemini model to latest flash variant

### DIFF
--- a/netlify/functions/generatePlan.js
+++ b/netlify/functions/generatePlan.js
@@ -20,7 +20,7 @@ exports.handler = async function (event, context) {
       };
     }
 
-    const model = process.env.GEMINI_MODEL || "gemini-1.5-flash";
+    const model = process.env.GEMINI_MODEL || "gemini-1.5-flash-latest";
     const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
 
     const response = await fetch(apiUrl, {

--- a/pages/api/generatePlan.js
+++ b/pages/api/generatePlan.js
@@ -15,7 +15,7 @@ export default async function handler(req, res) {
       return;
     }
 
-    const model = process.env.GEMINI_MODEL || 'gemini-1.5-flash';
+    const model = process.env.GEMINI_MODEL || 'gemini-1.5-flash-latest';
     const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
     const response = await fetch(apiUrl, {
       method: 'POST',


### PR DESCRIPTION
## Summary
- update the default Gemini model string used in both serverless endpoints to gemini-1.5-flash-latest

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64d425944832e9654932865f1bc06