### PR TITLE
Remove Hangul label from table generator navigation

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -144,7 +144,7 @@
                         <span id="user-email" class="text-sm text-gray-600"></span>
                         <a href="#home" id="nav-home" class="nav-link">홈</a>
                         <a href="#plan" id="nav-plan" class="nav-link">계획서</a>
-                        <a href="#table" id="nav-table" class="nav-link">[한글] 표 만들기(HWP)</a>
+                        <a href="#table" id="nav-table" class="nav-link">표 만들기(HWP)</a>
                         <a href="#official" id="nav-official" class="nav-link">기안문</a>
                         <a href="#letter" id="nav-letter" class="nav-link">가정통신문</a>
                         <button id="logout-btn" class="text-sm bg-red-500 hover:bg-red-600 text-white font-semibold py-1 px-3 rounded-md transition-colors">로그아웃</button>
@@ -289,7 +289,7 @@
                 <!-- Table Generator View -->
                 <div id="table-view" class="hidden">
                     <div class="container mx-auto p-6">
-                        <h2 class="text-3xl font-bold mb-6">[한글] 표 만들기(HWP)</h2>
+                        <h2 class="text-3xl font-bold mb-6">표 만들기(HWP)</h2>
                         <div class="flex flex-col lg:flex-row gap-6">
                             <!-- Input & Modify Section -->
                             <aside class="w-full lg:w-1/3 space-y-6">


### PR DESCRIPTION
## Summary
- remove the "[한글]" prefix from the table generator navigation link and heading on the public landing page

## Testing
- not run (static text change)


------
https://chatgpt.com/codex/tasks/task_e_68d64e3ccd18832ea3c2946bb155885a