### PR TITLE
Force Gemini latest flash model across app

### DIFF
--- a/netlify/functions/generatePlan.js
+++ b/netlify/functions/generatePlan.js
@@ -10,8 +10,21 @@ exports.handler = async function (event, context) {
   }
 
   try {
-    const { prompt } = JSON.parse(event.body);
+    const { prompt, model: requestedModel } = JSON.parse(event.body);
     const apiKey = process.env.GEMINI_API_KEY; // Netlify에 저장된 API 키 사용
+    const DEFAULT_MODEL = "gemini-1.5-flash-latest";
+
+    if (process.env.GEMINI_MODEL && process.env.GEMINI_MODEL !== DEFAULT_MODEL) {
+      console.warn(
+        `Ignoring GEMINI_MODEL environment override (${process.env.GEMINI_MODEL}) in favour of ${DEFAULT_MODEL}.`
+      );
+    }
+
+    if (requestedModel && requestedModel !== DEFAULT_MODEL) {
+      console.warn(
+        `Ignoring client-specified model (${requestedModel}); using ${DEFAULT_MODEL} instead.`
+      );
+    }
 
     if (!prompt) {
       return {
@@ -20,7 +33,7 @@ exports.handler = async function (event, context) {
       };
     }
 
-    const model = process.env.GEMINI_MODEL || "gemini-1.5-flash-latest";
+    const model = DEFAULT_MODEL;
     const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
 
     const response = await fetch(apiUrl, {

--- a/pages/api/generatePlan.js
+++ b/pages/api/generatePlan.js
@@ -7,15 +7,28 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { prompt } = req.body;
+    const { prompt, model: requestedModel } = req.body;
     const apiKey = process.env.GEMINI_API_KEY;
+    const DEFAULT_MODEL = 'gemini-1.5-flash-latest';
+
+    if (process.env.GEMINI_MODEL && process.env.GEMINI_MODEL !== DEFAULT_MODEL) {
+      console.warn(
+        `Ignoring GEMINI_MODEL environment override (${process.env.GEMINI_MODEL}) in favour of ${DEFAULT_MODEL}.`
+      );
+    }
+
+    if (requestedModel && requestedModel !== DEFAULT_MODEL) {
+      console.warn(
+        `Ignoring client-specified model (${requestedModel}); using ${DEFAULT_MODEL} instead.`
+      );
+    }
 
     if (!prompt) {
       res.status(400).json({ error: 'Prompt is required.' });
       return;
     }
 
-    const model = process.env.GEMINI_MODEL || 'gemini-1.5-flash-latest';
+    const model = DEFAULT_MODEL;
     const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
     const response = await fetch(apiUrl, {
       method: 'POST',

--- a/public/index.html
+++ b/public/index.html
@@ -499,6 +499,8 @@
         const letterView = document.getElementById('letter-view');
         const recentPlansList = document.getElementById('recent-plans-list');
         const form = document.getElementById('plan-form');
+        const GEMINI_MODEL = 'gemini-1.5-flash-latest';
+
         const generateBtn = document.getElementById('generate-btn');
         const initialMessage = document.getElementById('initial-message');
         const loadingIndicator = document.getElementById('loading-indicator');
@@ -832,7 +834,7 @@
                     const response = await fetch('/.netlify/functions/generatePlan', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ prompt })
+                        body: JSON.stringify({ prompt, model: GEMINI_MODEL })
                     });
                     const result = await response.json();
                     if (result.candidates?.[0]?.content?.parts?.[0]?.text) {
@@ -902,7 +904,7 @@
                     const response = await fetch('/.netlify/functions/generatePlan', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ prompt })
+                        body: JSON.stringify({ prompt, model: GEMINI_MODEL })
                     });
                     const result = await response.json();
                     if (result.candidates?.[0]?.content?.parts?.[0]?.text) {
@@ -1174,7 +1176,7 @@
                         const parseRes = await fetch('/.netlify/functions/generatePlan', {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ prompt: parsePrompt })
+                            body: JSON.stringify({ prompt: parsePrompt, model: GEMINI_MODEL })
                         });
                         const parseResult = await parseRes.json();
                         const text = parseResult.candidates?.[0]?.content?.parts?.[0]?.text;
@@ -1221,7 +1223,7 @@
                     const response = await fetch('/.netlify/functions/generatePlan', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ prompt })
+                        body: JSON.stringify({ prompt, model: GEMINI_MODEL })
                     });
                     const result = await response.json();
                     if (result.candidates?.[0]?.content?.parts?.[0]?.text) {
@@ -1318,7 +1320,7 @@
                     const response = await fetch('/.netlify/functions/generatePlan', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ prompt })
+                        body: JSON.stringify({ prompt, model: GEMINI_MODEL })
                     });
                     const result = await response.json();
                     if (result.candidates?.[0]?.content?.parts?.[0]?.text) {
@@ -1359,7 +1361,7 @@
                     const response = await fetch('/.netlify/functions/generatePlan', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ prompt })
+                        body: JSON.stringify({ prompt, model: GEMINI_MODEL })
                     });
                     const result = await response.json();
                     if (result.candidates?.[0]?.content?.parts?.[0]?.text) {
@@ -1426,7 +1428,7 @@
                     const response = await fetch('/.netlify/functions/generatePlan', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ prompt })
+                        body: JSON.stringify({ prompt, model: GEMINI_MODEL })
                     });
                     const result = await response.json();
                     if (result.candidates?.[0]?.content?.parts?.[0]?.text) {
@@ -1913,7 +1915,7 @@
                 const response = await fetch(apiUrl, { 
                     method: 'POST', 
                     headers: { 'Content-Type': 'application/json' }, 
-                    body: JSON.stringify({ prompt: prompt }) 
+                    body: JSON.stringify({ prompt: prompt, model: GEMINI_MODEL })
                 });
 
                 if (!response.ok) {
@@ -2604,7 +2606,7 @@
                 const response = await fetch('/.netlify/functions/generatePlan', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({ prompt })
+                    body: JSON.stringify({ prompt, model: GEMINI_MODEL })
                 });
                 const result = await response.json();
                 const text = result.candidates?.[0]?.content?.parts?.[0]?.text;
@@ -2679,7 +2681,7 @@ async function saveCurrentPlan() {
                     const response = await fetch('/.netlify/functions/generatePlan', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ prompt })
+                        body: JSON.stringify({ prompt, model: GEMINI_MODEL })
                     });
                     const result = await response.json();
                     const text = result.candidates?.[0]?.content?.parts?.[0]?.text;
@@ -2789,7 +2791,7 @@ async function saveCurrentPlan() {
                     const response = await fetch('/.netlify/functions/generatePlan', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ prompt })
+                        body: JSON.stringify({ prompt, model: GEMINI_MODEL })
                     });
                     const result = await response.json();
                     const text = result.candidates?.[0]?.content?.parts?.[0]?.text;
@@ -2882,7 +2884,7 @@ async function saveCurrentPlan() {
                     const response = await fetch('/.netlify/functions/generatePlan', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ prompt })
+                        body: JSON.stringify({ prompt, model: GEMINI_MODEL })
                     });
                     const result = await response.json();
                     const text = result.candidates?.[0]?.content?.parts?.[0]?.text;
@@ -3003,7 +3005,7 @@ async function saveCurrentPlan() {
                     const response = await fetch('/.netlify/functions/generatePlan', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ prompt })
+                        body: JSON.stringify({ prompt, model: GEMINI_MODEL })
                     });
                     const result = await response.json();
                     const text = result.candidates?.[0]?.content?.parts?.[0]?.text;


### PR DESCRIPTION
## Summary
- ensure the Netlify and Next.js generatePlan handlers always call the gemini-1.5-flash-latest model and ignore overrides that point to deprecated versions
- send the enforced model identifier from index.html for every Gemini generation request so the front-end stays in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d64f57dfc8832e813315fd8ae5747a