### PR TITLE
Hide initial placeholder when rendering plans

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2643,6 +2643,10 @@
         function displayContent(rawText, defaultPlanType, summaryMarkdown = null) {
             let content = rawText;
 
+            if (initialMessage) {
+                initialMessage.classList.add('hidden');
+            }
+
             const titleMatch = content.match(/^TITLE:\s*(.*)/m);
             const mainTitle = titleMatch && titleMatch[1] ? titleMatch[1].trim() : defaultPlanType;
             if (titleMatch) {


### PR DESCRIPTION
## Summary
- hide the initial output placeholder whenever displayContent renders a generated or saved plan

## Testing
- not run (static project)


------
https://chatgpt.com/codex/tasks/task_e_68d68e28036c832e8aa1423dfca7edd8